### PR TITLE
外部リンクを道のものに置き換え

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -78,7 +78,7 @@
     "Official statements from Task Force": "北海道感染症危機管理対策本部会議",
     "Cancelled public events": "【東京都主催等】中止または延期するイベント・説明会等",
     "Government official website": "東京都公式ホームページ",
-    "Message from Governor Koike": "知事からのメッセージ",
+    "Message from Governor Suzuki": "知事からのメッセージ",
     "About us": "当サイトについて"
   }
 }
@@ -138,9 +138,9 @@ export default {
             'https://www.seisakukikaku.metro.tokyo.lg.jp/information/event02.html'
         },
         {
-          title: this.$t('Message from Governor Koike'),
+          title: this.$t('Message from Governor Suzuki'),
           link:
-            'https://www.metro.tokyo.lg.jp/tosei/governor/governor/katsudo/2020/03/03_00.html'
+            'http://www.pref.hokkaido.lg.jp/ss/tkk/hodo/pressconference/r1.htm'
         },
         {
           title: this.$t('About us'),

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -76,7 +76,6 @@
     "for Citizens": "道民の皆様へ",
     "for Enterprises and Employees": "企業の皆様・はたらく皆様へ",
     "Official statements from Task Force": "北海道感染症危機管理対策本部会議",
-    "Cancelled public events": "【東京都主催等】中止または延期するイベント・説明会等",
     "Government official website": "北海道公式ホームページ",
     "Message from Governor Suzuki": "知事からのメッセージ",
     "About us": "当サイトについて"
@@ -132,11 +131,13 @@ export default {
           link:
             'http://www.pref.hokkaido.lg.jp/hf/kth/kak/singatakoronahaien.htm#対策本部'
         },
-        {
-          title: this.$t('Cancelled public events'),
-          link:
-            'https://www.seisakukikaku.metro.tokyo.lg.jp/information/event02.html'
-        },
+        // 【東京都主催等】中止または延期するイベント・説明会等
+        // 道にまとまった情報がないので一旦コメントアウト
+        // {
+        //   title: this.$t('Cancelled public events'),
+        //   link:
+        //     'https://www.seisakukikaku.metro.tokyo.lg.jp/information/event02.html'
+        // },
         {
           title: this.$t('Message from Governor Suzuki'),
           link:

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -77,7 +77,7 @@
     "for Enterprises and Employees": "企業の皆様・はたらく皆様へ",
     "Official statements from Task Force": "北海道感染症危機管理対策本部会議",
     "Cancelled public events": "【東京都主催等】中止または延期するイベント・説明会等",
-    "Government official website": "東京都公式ホームページ",
+    "Government official website": "北海道公式ホームページ",
     "Message from Governor Suzuki": "知事からのメッセージ",
     "About us": "当サイトについて"
   }
@@ -148,7 +148,7 @@ export default {
         },
         {
           title: this.$t('Government official website'),
-          link: 'https://www.metro.tokyo.lg.jp/',
+          link: 'http://www.pref.hokkaido.lg.jp/index.htm',
           divider: true
         }
       ]

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -45,10 +45,10 @@
       </v-list>
       <div class="SideNavigation-Footer">
         <div class="SideNavigation-SocialLinkContainer">
-          <a href="https://line.me/R/ti/p/%40822sysfc" target="_blank" rel="noopener">
+          <!-- <a href="https://line.me/R/ti/p/%40822sysfc" target="_blank" rel="noopener">
             <img src="/line.png" alt="LINE" />
-          </a>
-          <a href="https://twitter.com/tokyo_bousai" target="_blank" rel="noopener">
+          </a> -->
+          <a href="https://twitter.com/PrefHokkaido" target="_blank" rel="noopener">
             <img src="/twitter.png" alt="Twitter" />
           </a>
         </div>

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -75,7 +75,7 @@
     "for Families with children": "お子様をお持ちの皆様へ",
     "for Citizens": "道民の皆様へ",
     "for Enterprises and Employees": "企業の皆様・はたらく皆様へ",
-    "Official statements from Task Force": "東京都新型コロナウイルス感染症対策本部報",
+    "Official statements from Task Force": "北海道感染症危機管理対策本部会議",
     "Cancelled public events": "【東京都主催等】中止または延期するイベント・説明会等",
     "Government official website": "東京都公式ホームページ",
     "Message from Governor Koike": "知事からのメッセージ",
@@ -130,7 +130,7 @@ export default {
         {
           title: this.$t('Official statements from Task Force'),
           link:
-            'https://www.bousai.metro.tokyo.lg.jp/taisaku/saigai/1007261/index.html'
+            'http://www.pref.hokkaido.lg.jp/hf/kth/kak/singatakoronahaien.htm#対策本部'
         },
         {
           title: this.$t('Cancelled public events'),

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -73,7 +73,7 @@
     "The latest updates": "都内の最新感染動向",
     "If you have any symptoms": "新型コロナウイルス感染症が心配なときに",
     "for Families with children": "お子様をお持ちの皆様へ",
-    "for Citizens": "都民の皆様へ",
+    "for Citizens": "道民の皆様へ",
     "for Enterprises and Employees": "企業の皆様・はたらく皆様へ",
     "Official statements from Task Force": "東京都新型コロナウイルス感染症対策本部報",
     "Cancelled public events": "【東京都主催等】中止または延期するイベント・説明会等",
@@ -119,7 +119,7 @@ export default {
         {
           icon: 'mdi-account-multiple',
           title: this.$t('for Citizens'),
-          link: 'https://www.metro.tokyo.lg.jp/tosei/tosei/news/2019-ncov.html'
+          link: 'http://www.pref.hokkaido.lg.jp/ss/tkk/singatakoronahaien.htm'
         },
         {
           icon: 'mdi-domain',

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -20,12 +20,12 @@ export default {
         {
           title: '1 感染予防・健康管理',
           body:
-            '〇　不特定多数の人の集まる場所等への外出を避け、基本的に自宅で過ごしてください。<br />〇　手洗い、咳エチケット等により、感染予防に努めてください。<br />　<a href="https://tokyodouga.jp/lViN9C_BS-0.html" target="_blank" rel="noopener">【参考】感染症予防のための正しい手洗い方法（動画）</a> <br />〇　規則正しい生活を心がけ、日常の健康管理に十分気を付けてください。'
+            '〇　不特定多数の人の集まる場所等への外出を避け、基本的に自宅で過ごしてください。<br />〇　手洗い、咳エチケット等により、感染予防に努めてください。<br />　<a href="http://www.pref.hokkaido.lg.jp/hf/kth/tearai.pdf" target="_blank" rel="noopener">正しい手の洗い方</a> <br />〇　規則正しい生活を心がけ、日常の健康管理に十分気を付けてください。'
         },
         {
           title: '2 感染症を疑う場合の対応',
           body:
-            '〇　風邪の症状や、37.5度以上の発熱が４日以上続いている、強いだるさ（倦怠感）、息苦しさ（呼吸困難）がある場合は、各保健所にご相談ください。<br />〇  「新型コロナウイルス感染症にかかる相談窓口について」（東京都福祉保健局）<br /><a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html</a>'
+            '〇　風邪の症状や、37.5度以上の発熱が４日以上続いている、強いだるさ（倦怠感）、息苦しさ（呼吸困難）がある場合は、各保健所にご相談ください。<br />〇  相談窓口及び帰国者・接触者相談センターについて<br /><a href="http://www.pref.hokkaido.lg.jp/hf/kth/kak/singatakoronahaien.htm#%E7%9B%B8%E8%AB%87%E7%AA%93%E5%8F%A3" target="_blank" rel="noopener">http://www.pref.hokkaido.lg.jp/hf/kth/kak/singatakoronahaien.htm#%E7%9B%B8%E8%AB%87%E7%AA%93%E5%8F%A3</a>'
         },
         {
           title: '3 その他',

--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -18,19 +18,14 @@ export default {
     return {
       items: [
         {
-          title: '中小企業者等特別相談窓口',
+          title: '中小企業向け相談窓口及び融資取扱について',
           body:
-            '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html</a> <br />資金繰りに関する相談、経営に関する相談（東京都産業労働局　報道発表）'
+            '<a href="http://www.pref.hokkaido.lg.jp/kz/csk/kny/yuushi/korona.htm" target="_blank" rel="noopener">http://www.pref.hokkaido.lg.jp/kz/csk/kny/yuushi/korona.htm</a> <br />新型コロナウイルス関連肺炎の流行に伴う中小企業向け相談窓口及び融資取扱について'
         },
         {
-          title: '緊急労働相談ダイヤル',
+          title: '新型コロナ感染症の影響による特別労働相談窓口',
           body:
-            '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/02/26/22.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/02/26/22.html</a><br />新型コロナウイルスに関する休暇や休業の取り扱い、職場のハラスメントなどについての相談（東京都産業労働局　報道発表）'
-        },
-        {
-          title: '新しいワークスタイルや企業活動の東京モデル「スムーズビズ」',
-          body:
-            '<a href="https://smooth-biz.metro.tokyo.lg.jp/" target="_blank" rel="noopener">https://smooth-biz.metro.tokyo.lg.jp/</a><br />テレワーク・時差出勤などスムーズビズの取組は、新型コロナウイルス感染症の対策としても効果的です。感染症対策として、東京2020大会時の交通混雑緩和に向けた取組の前倒しをお願いします。'
+            '<a href="http://www.pref.hokkaido.lg.jp/kz/rkr/korona.htm" target="_blank" rel="noopener">http://www.pref.hokkaido.lg.jp/kz/rkr/korona.htm</a><br />今般の新型コロナウイルス感染症により影響を受ける事業主、労働者の方向けの、相談窓口や各種支援措置をお知らせします。'
         }
       ]
     }


### PR DESCRIPTION
## 📝 関連issue
- #17

## ⛏ 変更内容
- 外部リンク先が都になっていたものを、道で内容の近いものに変更
- 該当する情報が道にない場合は削除
- リンクのテキストを道のものに変更
- 外部リンクしない静的テキスト等は別途対応のつもりです

## 📸 スクリーンショット
![スクリーンショット 2020-03-06 15 16 48](https://user-images.githubusercontent.com/3221619/76057737-b8140980-5fbd-11ea-80a1-c4f2993b6222.png)
![スクリーンショット 2020-03-06 15 17 49](https://user-images.githubusercontent.com/3221619/76057740-b9ddcd00-5fbd-11ea-8278-a6afad67b0a9.png)
![スクリーンショット 2020-03-06 15 17 54](https://user-images.githubusercontent.com/3221619/76057745-bc402700-5fbd-11ea-945a-fb1634531c4c.png)
