### PR TITLE
都営地下鉄の利用者数の推移を削除

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -68,14 +68,6 @@
           :unit="'件'"
         />
       </v-col>
-      <v-col cols="12" md="6" class="DataCard">
-        <metro-bar-chart
-          title="都営地下鉄の利用者数の推移"
-          :chart-data="metroGraph"
-          :chart-option="metroGraphOption"
-          :date="metroGraph.date"
-        />
-      </v-col>
     </v-row>
   </div>
 </template>
@@ -83,12 +75,10 @@
 <script>
 import PageHeader from '@/components/PageHeader.vue'
 import TimeBarChart from '@/components/TimeBarChart.vue'
-import MetroBarChart from '@/components/MetroBarChart.vue'
 import TimeStackedBarChart from '@/components/TimeStackedBarChart.vue'
 import WhatsNew from '@/components/WhatsNew.vue'
 import StaticInfo from '@/components/StaticInfo.vue'
 import Data from '@/data/data.json'
-import MetroData from '@/data/metro.json'
 import DataTable from '@/components/DataTable.vue'
 import formatGraph from '@/utils/formatGraph'
 import formatTable from '@/utils/formatTable'
@@ -98,7 +88,6 @@ export default {
   components: {
     PageHeader,
     TimeBarChart,
-    MetroBarChart,
     TimeStackedBarChart,
     WhatsNew,
     StaticInfo,
@@ -118,8 +107,6 @@ export default {
     const contactsGraph = formatGraph(Data.contacts.data)
     // 帰国者・接触者電話相談センター相談件数
     const querentsGraph = formatGraph(Data.querents.data)
-    // 都営地下鉄の利用者数の推移
-    const metroGraph = MetroData
     // 検査実施日別状況
     const inspectionsGraph = [
       Data.inspections_summary.data['都内'],
@@ -152,7 +139,6 @@ export default {
       dischargesGraph,
       contactsGraph,
       querentsGraph,
-      metroGraph,
       inspectionsGraph,
       inspectionsItems,
       inspectionsLabels,
@@ -205,60 +191,6 @@ export default {
               }
             }
           ]
-        }
-      },
-      metroGraphOption: {
-        responsive: true,
-        legend: {
-          display: true
-        },
-        scales: {
-          xAxes: [
-            {
-              position: 'bottom',
-              stacked: false,
-              gridLines: {
-                display: true
-              },
-              ticks: {
-                fontSize: 10,
-                maxTicksLimit: 20,
-                fontColor: '#808080'
-              }
-            }
-          ],
-          yAxes: [
-            {
-              stacked: false,
-              gridLines: {
-                display: true
-              },
-              ticks: {
-                fontSize: 10,
-                maxTicksLimit: 10,
-                fontColor: '#808080',
-                callback(value) {
-                  // 基準値を100としたときの相対値
-                  return (value / 100).toFixed(2)
-                }
-              }
-            }
-          ]
-        },
-        tooltips: {
-          displayColors: false,
-          callbacks: {
-            title(tooltipItems, _) {
-              const label = tooltipItems[0].label
-              return `期間: ${label}`
-            },
-            label(tooltipItem, data) {
-              const currentData = data.datasets[tooltipItem.datasetIndex]
-              const percentage = `${currentData.data[tooltipItem.index]}%`
-
-              return `${metroGraph.base_period}の利用者数との相対値: ${percentage}`
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
## 📝 関連issue
- #5 

## ⛏ 変更内容
- 「都営地下鉄の利用者数の推移」を削除

## 📸 スクリーンショット
![image](https://user-images.githubusercontent.com/9605526/76132351-e9401880-6055-11ea-9bac-fd55c868a808.png)
