### PR TITLE
「新型コロナウイルス感染症が心配なときに」のリンク先変更

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -76,7 +76,7 @@
     "Tokyo Metropolitan Government": "東京都",
     "Tokyo COVID-19 Task Force": "新型コロナウイルス感染症対策本部",
     "The latest updates": "道内の最新感染動向",
-    "If you have any symptoms": "新型コロナウイルス感染症が心配なときに",
+    "If you have any symptoms": "感染予防と相談窓口",
     "for Families with children": "お子様をお持ちの皆様へ",
     "for Citizens": "道民の皆様へ",
     "for Enterprises and Employees": "企業の皆様・はたらく皆様へ",

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -112,7 +112,7 @@ export default {
         {
           icon: 'covid',
           title: this.$t('If you have any symptoms'),
-          link: '/flow',
+          link: 'http://www.pref.hokkaido.lg.jp/hf/kth/kak/singatakoronahaien.htm#道民へ',
           divider: true
         },
         {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,12 +11,6 @@
       url="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/03/03/28.html"
       text="新型コロナウイルスに関連した患者の発生について（第65報）"
     />
-    <StaticInfo
-      class="mb-4"
-      :url="'/flow'"
-      :text="'自分や家族の症状に不安や心配があればまずは電話相談をどうぞ'"
-      :btn-text="'相談の手順を見る'"
-    />
     <v-row class="DataBlock">
       <v-col cols="12" md="6" class="DataCard">
         <svg-card


### PR DESCRIPTION
## 📝 関連issue
#30 

## ⛏ 変更内容
V0向けの暫定対応です。

- 「新型コロナウイルス感染症が心配なときに」のリンク先を暫定的に外部リンクに飛ばしました。
http://www.pref.hokkaido.lg.jp/hf/kth/kak/singatakoronahaien.htm#道民へ
選択理由: 相談フローと相談先が一番まとまっている。道の情報ソースであること。

- 内容が暫定なので、トップの目立つ位置からのリンクは消しました。
下のスクショは東京都のもの。赤枠の部分を消しました。
<img width="370" alt="スクリーンショット 2020-03-07 15 53 22" src="https://user-images.githubusercontent.com/3221619/76138482-e19b6680-608b-11ea-8ec4-39eec4bf425a.png">

- タイトルもそれらしい文言に調整しました。
<img width="236" alt="スクリーンショット 2020-03-07 15 55 11" src="https://user-images.githubusercontent.com/3221619/76138505-19a2a980-608c-11ea-9a83-2109ded23751.png">