### PR TITLE
'検査陽性者の状況' を削除

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,13 +13,6 @@
     />
     <v-row class="DataBlock">
       <v-col cols="12" md="6" class="DataCard">
-        <svg-card
-          :title="'検査陽性者の状況'"
-          :src-url="'confirmed-cases-table.svg'"
-          :date="'2020/3/4 19:30 '"
-        />
-      </v-col>
-      <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
           title="陽性患者数"
           :chart-data="patientsGraph"


### PR DESCRIPTION
## 📝 関連issue
#61

## ⛏ 変更内容
V0では一旦、`検査陽性者の状況` を非表示にしたらどうかなと思いました。
V1以降での見せ方は引き続き #61 で議論できたらと思います。

## 📸 スクリーンショット
<img width="1057" alt="スクリーンショット 2020-03-08 16 17 44" src="https://user-images.githubusercontent.com/3221619/76158357-7c617700-6158-11ea-979a-9d29f37e0edc.png">
