### PR TITLE
what's new を手作業更新 3/7

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,9 +7,9 @@
     />
     <whats-new
       class="mb-4"
-      date="2020年3月3日"
-      url="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/03/03/28.html"
-      text="新型コロナウイルスに関連した患者の発生について（第65報）"
+      date="2020年3月7日"
+      url="http://www.pref.hokkaido.lg.jp/hf/kth/kak/hasseijyoukyou0308yousei_0307genzai.pdf"
+      text="北海道における新型コロナウイルス感染症の検査陽性者の状況（R2.3.7現在）"
     />
     <v-row class="DataBlock">
       <v-col cols="12" md="6" class="DataCard">


### PR DESCRIPTION
## 📝 関連issue 
#41 

## ⛏ 変更内容
what's new の領域を手作業で更新しました。
とりあえず、ここへのリンクにしました。
http://www.pref.hokkaido.lg.jp/hf/kth/kak/hasseijyoukyou0308yousei_0307genzai.pdf

#84 の対応でグラフが非表示になるので、その代わりにってことで。

## 📸 スクリーンショット
こんな感じで。
<img width="867" alt="スクリーンショット 2020-03-08 16 35 51" src="https://user-images.githubusercontent.com/3221619/76158700-0e1eb380-615c-11ea-90d5-0902e6a09b62.png">
