### PR TITLE
陽性患者の属性のグラフの高さを大きくする（データの特性上改行が入ってしまうのを考慮

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -8,7 +8,7 @@
       :items="chartData.datasets"
       :items-per-page="-1"
       :hide-default-footer="true"
-      :height="200"
+      :height="300"
       :fixed-header="true"
       :mobile-breakpoint="0"
       class="cardTable"


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close #109 

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- 居住地の文字列が長くて改行が入ってしまうのはしょうがないので、単純にグラフの高さを高くしました

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->

after
<img width="828" alt="スクリーンショット 2020-03-08 22 41 46" src="https://user-images.githubusercontent.com/32258949/76163975-260f2b00-618e-11ea-80d0-3cf72270a6b8.png">


 before

<img width="398" alt="スクリーンショット 2020-03-08 22 15 49" src="https://user-images.githubusercontent.com/32258949/76163980-30312980-618e-11ea-9cd1-43e967d5be21.png">

