### PR TITLE
陽性患者数のみ初期状態で累計が表示されるよう修正

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -53,11 +53,16 @@ export default {
       type: String,
       required: false,
       default: ''
+    },
+    defaultDataKind: {
+      type: String,
+      required: false,
+      default: 'transition'
     }
   },
   data() {
     return {
-      dataKind: 'transition'
+      dataKind: this.defaultDataKind
     }
   },
   computed: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -20,6 +20,7 @@
           sourceFrom="北海道庁webサイト"
           sourceLink="http://www.pref.hokkaido.lg.jp/ss/tkk/singatakoronahaien.htm"
           :unit="'人'"
+          :defaultDataKind="'cumulative'"
         />
       </v-col>
       <v-col cols="12" md="6" class="DataCard">


### PR DESCRIPTION
## 📝 関連issue
- close #116 

## ⛏ 変更内容
陽性患者数のみ累計がデフォルトになるようにしてみました

## 📸 スクリーンショット
<img width="839" alt="スクリーンショット 2020-03-09 1 25 53" src="https://user-images.githubusercontent.com/3221619/76166832-fcadc980-61a4-11ea-8aae-681d55a43b7e.png">
