### PR TITLE
docker-compose がうまく動作しない場合のトラブルシュートを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This software is released under the MIT License.
 
 ### How to Set Up Environments / 環境構築の手順
 
-**Use yarn / yarn を使う場合**
+#### Use yarn / yarn を使う場合**
 ``` bash
 # install dependencies
 $ yarn install
@@ -55,10 +55,29 @@ $ yarn install
 $ yarn dev
 ```
 
-**Use docker / docker compose を使う場合**
+#### Use docker / docker compose を使う場合
 ```bash 
 # serve with hot reload at localhost:3000
 $ docker-compose up
+```
+
+* `docker-compose up` 初回実行時に下記のエラーが出た場合
+
+```
+yarn run v1.21.1
+$ cross-env NODE_ENV=development nuxt-ts
+covid19 | /bin/sh: cross-env: not found
+error Command failed with exit code 127.
+info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+covid19 exited with code 127
+```
+
+なんらかの理由で`yarn install`が失敗していると考えられるので、下記を実行後、再度 `docker-compose up` してみてください。
+
+```bash
+$ docker-compose exec app sh
+/app # yarn install
+/app # exit
 ```
 
 ### Deployment to Staging & Production Environments / ステージング・本番環境への反映


### PR DESCRIPTION
## ⛏ 変更内容
`docker-compose up` で開発環境を立ち上げたところエラーで落ちたので
対応方法をREADMEに追加しておきました。
動作確認ずみです。

根本解決できたほうが良いとは思いますが、暫定的に動かすための情報を載せておいたほうが良いと思いました。