### PR TITLE
本番環境も明示的にrobots.txtを出力するようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn run test
       - run: yarn run generate --fail-on-page-error
+      - run: "echo \"User-agent: *\nAllow: /\" > ./dist/robots.txt"
 
       - name: archive dist
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close #119 

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- 本番用にビルドする時に、`Allow /` なrobots.txtを吐き出すようにしました

## リリース時の注意

現在、本番サーバ側で独自に作成したrobots.txtファイルがあるため、削除してからリリースしないとデプロイに失敗しそう

