### PR TITLE
Feature/189 remove kanagawa

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -105,8 +105,7 @@
     "About us": "当サイトについて",
     "Government official Twitter": "北海道公式Twitter",
     "Other local Government": "他自治体の対策サイト",
-    "Tokyo": "東京",
-    "Kanagawa": "神奈川"
+    "Tokyo": "東京"
   }
 }
 </i18n>
@@ -190,13 +189,9 @@ export default {
         },
         {
           title: this.$t('Tokyo'),
-          link: 'https://stopcovid19.metro.tokyo.lg.jp/'
-        },
-        {
-          title: this.$t('Kanagawa'),
-          link: 'https://stopcovid19.kanagawa.work/',
+          link: 'https://stopcovid19.metro.tokyo.lg.jp/',
           divider: true
-        }
+        },
       ]
     },
     isClass() {

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -104,8 +104,7 @@
     "Message from Governor Suzuki": "知事からのメッセージ",
     "About us": "当サイトについて",
     "Government official Twitter": "北海道公式Twitter",
-    "Other local Government": "他自治体の対策サイト",
-    "Tokyo": "東京"
+    "Tokyo-to Measures site": "東京都 新型コロナウイルス感染症対策サイト"
   }
 }
 </i18n>
@@ -185,10 +184,7 @@ export default {
           divider: true
         },
         {
-          title: this.$t('Other local Government')
-        },
-        {
-          title: this.$t('Tokyo'),
+          title: this.$t('Tokyo-to Measures site'),
           link: 'https://stopcovid19.metro.tokyo.lg.jp/',
           divider: true
         },


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close #189 
- close #188 

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- 神奈川県のリンクを削除
- あわせて「他自治体の対策サイト」ヘッダーを削除

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->

<img width="375" alt="スクリーンショット 2020-03-10 23 53 11" src="https://user-images.githubusercontent.com/32258949/76325513-b97d6300-632a-11ea-8e6a-a245a8c6205d.png">
<img width="332" alt="スクリーンショット 2020-03-10 23 53 05" src="https://user-images.githubusercontent.com/32258949/76325524-bd10ea00-632a-11ea-9b7f-9668c9fb3dac.png">
