### PR TITLE
L字グラフを非表示

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,23 +14,6 @@
 
     <v-row class="DataBlock">
       <v-col cols="12" md="6" class="DataCard">
-          <DataView
-            title="検査陽性者の状況"
-            source-from="北海道 オープンデータポータル"
-            source-link="https://www.harp.lg.jp/opendata/dataset/1369.html"
-            date="2020/03/12"
-          >
-            <ConfiremCasesTable
-              :inspections="1250"
-              :nowpatients="71"
-              :currentpatients="128"
-              :milds="65"
-              :serious="6"
-              :losts="4"
-              :discharges="53" />
-          </DataView>
-      </v-col>
-      <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
           title="現在患者数"
           :chart-data="currentPatientsGraph"


### PR DESCRIPTION
## 📝 関連issue
- #241 

## ⛏ 変更内容

- L字グラフを非表示にします
- revertではなく、トップページから非表示にするだけです。componentはそのまま。

## 📸 スクリーンショット

<img width="1567" alt="スクリーンショット 2020-03-13 19 05 59" src="https://user-images.githubusercontent.com/32258949/76611357-b5855700-655d-11ea-8f27-d737f4454602.png">
