### PR TITLE
英語版リンクを単語の途中で改行されないように修正

### DIFF
--- a/components/TextCard.vue
+++ b/components/TextCard.vue
@@ -44,7 +44,7 @@ export default class TextCard extends Vue {
       @include body-text();
     }
     a {
-      word-break: break-all;
+      word-break: break-word;
       color: $link;
     }
   }


### PR DESCRIPTION
## 📝 関連issue
- close #289

## ⛏ 変更内容
- 英語版でTextCardのリンクを単語の途中で改行されないように修正

## 📸 スクリーンショット
修正前：
![英語版Aboutリンク改行](https://user-images.githubusercontent.com/5244112/77218463-db6ab700-6b6e-11ea-8770-f3a7c650ca9f.png)

修正後：
![英語版Aboutリンク改行修正](https://user-images.githubusercontent.com/5244112/77218414-6f884e80-6b6e-11ea-8848-3b6bb666a6b0.png)

修正後の日本語版：
![日本語版修正後のリンク改行](https://user-images.githubusercontent.com/5244112/77218469-e45b8880-6b6e-11ea-853f-741b28465468.png)

## 環境
Ubuntu 19.10, Firefox 74.0

