### PR TITLE
「累計」英訳の修正

### DIFF
--- a/components/DataSelector.i18n.json
+++ b/components/DataSelector.i18n.json
@@ -5,6 +5,6 @@
   },
   "en": {
     "日別": "Daily",
-    "累計": "Cumulative"
+    "累計": "Total"
   }
 }

--- a/components/TimeStackedBarChart.i18n.json
+++ b/components/TimeStackedBarChart.i18n.json
@@ -4,7 +4,7 @@
     "{date}の全体累計": "{date}の全体累計"
   },
   "en": {
-    "{date}の合計。{date}はグラフデータの日付。": "Total at {date}",
-    "{date}の全体累計。{date}はグラフデータの日付。": "Cumulative total at {date}"
+    "{date}の合計。": "Total at {date}",
+    "{date}の全体累計。": "Total at {date}"
   }
 }

--- a/pages/index.i18n.json
+++ b/pages/index.i18n.json
@@ -29,7 +29,7 @@
     "治療終了者数とは道発表の「陰性確認済累計」と同じものです。「陰性確認済累計」とは、陽性の患者が軽快してから48時間後の1回目のPCR検査で陰性が確認され、それから12時間後の2回目のPCR検査でも陰性が確認された方の累計のことです。（3/9 鈴木知事のツイートから引用）": "The number of discharged patients is the same as the Hokkaido Government's \"cumulative total of patients who have tested negative\". This refers to patients who tested negative on a PCR test 48 hours after their symptoms improved, and then tested negative again a further 12 hours after that. (Source: Governor Suzuki's March 9 tweet.)",
     "陽性患者数": "Confirmed cases",
     "陽性患者の属性": "Confirmed case details",
-    "{date}の累計": "Cumulative total as of {date}",
+    "{date}の累計": "Total at {date}",
     "検査数": "Tests conducted",
     "3月3日以前のデータが公開されていないため、グラフは3月3日以降となります。": "Data before March 3 is not publicly available.",
     "新型コロナコールセンター相談件数(札幌市保健所値)": "Consultations at COVID-19 help desk (Sapporo Health Office)",


### PR DESCRIPTION
## 📝 関連issue
- #38 

## ⛏ 変更内容
- 「Cumulative」を「Total」に修正。（翻訳Google Sheetの提案を引用）
- 間違った翻訳キーを合わせて修正。
