### PR TITLE
Feature/316 translate list move top

### DIFF
--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -80,7 +80,7 @@ export default Vue.extend({
   &::-ms-expand {
     display: none;
   }
-  
+
   border: 1px solid $gray-4;
   // 背景に被せて位置など調整
   z-index: 1;

--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -80,6 +80,7 @@ export default Vue.extend({
   &::-ms-expand {
     display: none;
   }
+  
   border: 1px solid $gray-4;
   // 背景に被せて位置など調整
   z-index: 1;

--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -1,108 +1,99 @@
 <template>
-  <div>
-    <v-select
+  <div class="LauguageSelector">
+    <div class="LauguageSelector-Background">
+      <EarthIcon class="EarthIcon" aria-hidden="true" />
+      <SelectMenuIcon class="SelectMenuIcon" aria-hidden="true" />
+    </div>
+    <select
+      id="LanguageSelector"
       v-model="currentLocaleCode"
-      width="100%"
-      :items="languages"
-      item-text="name"
-      item-value="code"
-      filled
-      label="Language"
-    />
+      class="LauguageSelector-Menu"
+      @change="handleChangeLanguage"
+    >
+      <option
+        v-for="locale in $i18n.locales"
+        :key="locale.code"
+        :value="locale.code"
+        :title="'Switch to ' + locale.description"
+      >
+        {{ locale.name }}
+      </option>
+    </select>
   </div>
 </template>
 
-<script>
-export default {
-  data() {
+<script lang="ts">
+import Vue from 'vue'
+import EarthIcon from '@/static/earth.svg'
+import SelectMenuIcon from '@/static/selectmenu.svg'
+type LocalData = {
+  currentLocaleCode: string
+}
+export default Vue.extend({
+  components: {
+    EarthIcon,
+    SelectMenuIcon
+  },
+  data(): LocalData {
     return {
-      currentLocaleCode: this.$i18n.locale,
-      languages: this.$i18n.locales
+      currentLocaleCode: this.$root.$i18n.locale
     }
   },
-  watch: {
-    currentLocaleCode(val) {
-      this.$i18n.setLocale(val)
+  methods: {
+    handleChangeLanguage() {
+      this.$root.$i18n.setLocale(this.currentLocaleCode)
     }
   }
-  /*
-  navigate() {
-    // @fixme 型が・・・
-    // const langs = this.$i18n.locales.filter() ...
-     const langs = ['ja', 'en', 'zh-cn', 'zh-tw', 'ko', 'ja-basic']
-    const pathes = this.$router.currentRoute.path.split('/').filter(path => {
-      return langs.includes(path) ? undefined : path
-    })
-    if (pathes.length <= 0) {
-      this.$router.push(locale === 'ja' ? '/' : '/' + locale)
-      return
-    }
-    const url =
-      locale === 'ja'
-        ? '/' + pathes.join('/')
-        : '/' + locale + '/' + pathes.join('/')
-    this.$router.push(url)
-    // TODO: 下の実装で問題なければ上のコメントを削除する
-  }
-  */
-}
+})
 </script>
 
-<style lang="scss">
-.SelectLanguage {
+<style lang="scss" scoped>
+.LauguageSelector {
   position: relative;
+}
+.LauguageSelector-Background {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  width: 100%;
-  background: #fff;
-  border: 1px solid #d9d9d9;
+  padding: 0 6px;
   border-radius: 4px;
-  cursor: pointer;
-  &-Menu {
-    width: 100%;
-    z-index: 1;
-    select {
-      width: 100%;
-      height: 28px;
-      background: transparent;
-      padding-left: 76px;
-      color: #333;
-      font-size: 16px;
-      transform: scale(0.75);
-      transform-origin: left;
-      box-sizing: border-box;
-      cursor: pointer;
-      &:focus {
-        outline: none;
-      }
-    }
+  height: 28px;
+  .EarthIcon {
+    order: -1;
   }
-  &-Background {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    .EarthIcon {
-      position: absolute;
-      left: 6px;
-      height: 28px;
-    }
-    .SelectMenuIcon {
-      position: absolute;
-      right: 6px;
-      height: 28px;
-    }
-    &::before {
-      content: 'Lang:';
-      display: inline-block;
-      position: absolute;
-      left: 24px;
-      color: #333;
-      font-size: 12px;
-      line-height: 28px;
-    }
+  .SelectMenuIcon {
+    margin-left: auto;
+  }
+  &::before {
+    content: 'Lang:';
+    margin-left: 4px;
+    color: $gray-1;
+    font-size: 12px;
+  }
+}
+.LauguageSelector-Menu {
+  // select 要素のリセット
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: transparent;
+  // IEで矢印ボタンを消す
+  &::-ms-expand {
+    display: none;
+  }
+  border: 1px solid $gray-4;
+  // 背景に被せて位置など調整
+  z-index: 1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding-left: 60px;
+  width: 100%;
+  height: 28px;
+  font-size: 12px;
+  line-height: 28px;
+  &:focus {
+    border: 1px dotted $gray-3;
+    outline: none;
   }
 }
 </style>

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -24,7 +24,6 @@
         </h1>
       </nuxt-link>
     </div>
-    <v-divider class="SideNavigation-HeadingDivider" />
     <div class="sp-none" :class="{ open: isNaviOpen }">
       <v-icon
         class="SideNavigation-ListContainerIcon sp-inline-block"
@@ -33,10 +32,10 @@
       >
         mdi-close
       </v-icon>
-
       <div class="SideNavigation-LanguageMenu">
         <LanguageSelector />
       </div>
+      <v-divider class="SideNavigation-HeadingDivider" />
 
       <v-list :flat="true">
         <v-container
@@ -263,7 +262,7 @@ export default {
   }
   &-ListContainerIcon {
     display: none;
-    margin: 24px 16px 0;
+    margin: 24px 16px 24px;
   }
   &-ListItemContainer {
     padding: 2px 20px;
@@ -297,7 +296,7 @@ export default {
     }
   }
   &-HeadingDivider {
-    margin: 0 20px 4px;
+    margin: 12px 20px 4px;
     @include lessThan($small) {
       display: none;
     }

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -33,6 +33,11 @@
       >
         mdi-close
       </v-icon>
+
+      <div class="SideNavigation-LanguageMenu">
+        <LanguageSelector />
+      </div>
+
       <v-list :flat="true">
         <v-container
           v-for="(item, i) in items"
@@ -45,9 +50,7 @@
           <v-divider v-show="item.divider" class="SideNavigation-Divider" />
         </v-container>
       </v-list>
-      <div class="SideNavigation-LanguageMenu">
-        <LanguageSelector />
-      </div>
+
       <div class="SideNavigation-Footer">
         <div class="SideNavigation-SocialLinkContainer">
           <!-- <a href="https://line.me/R/ti/p/%40822sysfc" target="_blank" rel="noopener">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     },
     "types": [
       "@types/node",
-      "@nuxt/types"
+      "@nuxt/types",
+      "nuxt-i18n"
     ]
   },
   "exclude": [


### PR DESCRIPTION
## 📝 関連issue
- close #316 

## ⛏ 変更内容
- 言語選択をサイドメニューの上に
- 東京都からほぼコピペでコンボボックスの見た目調整
  - 「多言語対応選択メニュー」というラベルは持ってきませんでした
    - 「多言語対応選択メニュー」自体を翻訳するほどの手間をかけてまで、必要性を感じなかったので

