### PR TITLE
codeforsapporo/covid19#258 他地域一覧へのリンク追加

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -215,7 +215,12 @@ export default {
         },
         {
           title: this.$t('東京都 新型コロナウイルス感染症対策サイト'),
-          link: 'https://stopcovid19.metro.tokyo.lg.jp/',
+          link: 'https://stopcovid19.metro.tokyo.lg.jp/'
+        },
+        {
+          title: this.$t('他地域 新型コロナウイルス感染症対策サイト一覧'),
+          link:
+            'https://github.com/tokyo-metropolitan-gov/covid19/blob/development/FORKED_SITES.md',
           divider: true
         }
       ]


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close #258 

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- https://github.com/tokyo-metropolitan-gov/covid19/blob/development/FORKED_SITES.md へのリンクを追加
- リンクテキストの翻訳は別途
- https://stopcovid19-ugc.netlify.com/#/ というのもあるけど、まだドメインが仮なのと、スマホ対応が微妙なので、ひとまずGitHubに直リンク
