### PR TITLE
docker-compose up 初回実行時のエラーが出た場合の回避方法を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ covid19 exited with code 127
 なんらかの理由で`yarn install`が失敗していると考えられるので、下記を実行後、再度 `docker-compose up` してみてください。
 
 ```bash
-$ docker-compose exec app sh
+$ docker-compose run --rm app sh
 /app # yarn install
 /app # exit
 ```


### PR DESCRIPTION
## ⛏ 変更内容
`docker-compose up`初回実行時に下記のエラーが出た場合，`docker-compose exec app sh`をしてもコンテナは起動されていないため`ERROR: No container found`が発生します．そのため`docer-compose run`でコンテナを新規で作成し，コンテナ内で`yarn install`することで`docker-compose up`がエラーなく実行できることがわかったため修正します．

<details>
<summary>docker-compose up 初回実行時に下記のエラーログ</summary>

```bash
❯ docker-compose up
Creating network "covid19_default" with the default driver
Building app
Step 1/8 : FROM node:10.19-alpine
・・省略・・
Successfully tagged covid19_app:latest
WARNING: Image for service app was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Creating covid19 ... done
Attaching to covid19
yarn run v1.21.1
$ cross-env NODE_ENV=development nuxt-ts
covid19 | /bin/sh: cross-env: not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
covid19 exited with code 127
```

</details>

`docker-compose exec app sh`をしてもコンテナは起動されていないため`ERROR: No container found`が発生する
```bash
❯ docker-compose exec app sh
ERROR: No container found for app_1
```

<details>
<summary>docker-compose exec app shでコンテナを新規で作成し，コンテナに入る</summary>

```
❯ docker-compose run app sh
/app # yarn install
yarn install v1.21.1
[1/4] Resolving packages...
[2/4] Fetching packages...
・・省略・・
/app # exit
```

</details>

<details>
<summary>docker-compose upがエラーなく実行される</summary>

```bash
❯ docker-compose up
Starting covid19 ... done
Attaching to covid19
yarn run v1.21.1
$ cross-env NODE_ENV=development nuxt-ts
covid19 | 
covid19 |  WARN  No .env file found in /app.
covid19 | 
covid19 | 
covid19 |    ╭─────────────────────────────────────────────╮
covid19 |    │                                             │
covid19 |    │   Nuxt.js v2.12.2                           │
covid19 |    │   Running in development mode (universal)   │
covid19 |    │                                             │
covid19 |    │   Listening on: http://172.19.0.2:3000/     │
covid19 |    │                                             │
covid19 |    ╰─────────────────────────────────────────────╯
covid19 | 
```

</details>