### PR TITLE
公表日のフォーマットに年(下二桁）を含める

### DIFF
--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -34,7 +34,7 @@ export default (data: DataType[]) => {
   }
   data.forEach(d => {
     const TableRow: TableDataType = {
-      公表日: dayjs(d['リリース日']).format('MM/DD') ?? '不明',
+      公表日: dayjs(d['リリース日']).format('YY/MM/DD') ?? '不明',
       居住地: d['居住地'] ?? '不明',
       年代: d['年代'] ?? '不明',
       性別: d['性別'] ?? '不明'


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #468

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「陽性患者属性」の公表日が「月日」のみのため2021年1月以降、前年同月のデータと混在していた（正確には前年データと一緒にソートされた結果、1月のデータが最も古いデータとして扱われていた）
- 公表日のフォーマットに年下二桁を追加することで、 veutifyの v-data-table側で正しくソートされるようになる

## 📸 スクリーンショット / Screenshots
年が増えることで大きくレイアウトが崩れることもなさそう
![スクリーンショット 2021-01-08 11 11 51（3）](https://user-images.githubusercontent.com/293996/103966097-8736cf00-51a2-11eb-8538-40e72651c3bb.png)

![スクリーンショット 2021-01-08 11 12 09（3）](https://user-images.githubusercontent.com/293996/103966110-8bfb8300-51a2-11eb-8558-8da987dc3b11.png)

